### PR TITLE
BUG: Fixes solution for tutorial 3

### DIFF
--- a/notebooks/solutions/groupby_00b.py
+++ b/notebooks/solutions/groupby_00b.py
@@ -1,3 +1,3 @@
-(df.groupby(df.text.str.count('\w'))
+(df.groupby(df.text.str.count('\w+'))
    .review_overall
    .mean().plot(style='k.'))


### PR DESCRIPTION
Exercise states:

> Find the relationship between review length (number of **words** and average `review_overall`.)

`\w` counts the number of alphanumeric characters + underscore.

`\w+` gives a better estimate of the number of words.